### PR TITLE
Removed dns entry hack from noahhuppert-com chart deploy

### DIFF
--- a/deploy/noahhuppert-com/Makefile
+++ b/deploy/noahhuppert-com/Makefile
@@ -1,10 +1,8 @@
 .PHONY: all build deploy rm dns
 
-NAMESPACE=noahhuppert-com
-CHART_NAME=noahhuppert-com
-SUB_DOMAIN=www.k8s
+NAME=noahhuppert-com
 
-# all builds and deploys the chart
+# all builds and deploys the site
 all: build deploy
 
 # build packages the external dns chart
@@ -15,19 +13,9 @@ build:
 deploy: 
 	helm upgrade \
 		--install \
-		--namespace "${NAMESPACE}" \
-		"${CHART_NAME}" .
+		--namespace "${NAME}" \
+		"${NAME}" .
 
 # rm deletes the app deployment from the cluster
 rm: 
-	helm delete --purge "${CHART_NAME}"
-
-# dns sets the intermediate records on the root domain to point to the auto 
-# app ingress resource.
-dns:
-	doctl compute domain records update noahh.io \
-		--record-id 35001486 \
-		--record-data $(shell dig +short "${SUB_DOMAIN}.noahh.io")
-	doctl compute domain records update noahhuppert.com \
-		--record-id 35001451 \
-		--record-data $(shell dig +short "${SUB_DOMAIN}.noahhuppert.com")
+	helm delete --purge "${NAME}"


### PR DESCRIPTION
# What and Why
Before external dns was working on the cluster I had a hack in the makefile which used the DigitalOcean CLI to manually modify DNS entries.  

External dns is now working properly so the hack is no longer needed.